### PR TITLE
2.4.0 Release

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,14 +1,14 @@
 language: python
 python:
-  - "2.7.12"
+  - "2.7"
   - "3.4"
   - "3.6"
-  - "3.7-dev"
+  - "3.7"
+  - "3.8"
 
 matrix:
   allow_failures:
-    - python: "2.7.12"
-    - python: "3.7-dev"
+    - python: "2.7"
 
 install:
   - pip install nose Faker codecov

--- a/README.md
+++ b/README.md
@@ -1,10 +1,36 @@
 ## **pyTeliumManager**
 ![Travis-CI](https://travis-ci.org/Ousret/pyTeliumManager.svg?branch=master) [![codecov](https://codecov.io/gh/Ousret/pyTeliumManager/branch/master/graph/badge.svg)](https://codecov.io/gh/Ousret/pyTeliumManager) [![Codacy Badge](https://api.codacy.com/project/badge/Grade/ff5c954c3c2348ce8f3a1b7bd76e964c)](https://www.codacy.com/app/Ousret/pyTeliumManager?utm_source=github.com&amp;utm_medium=referral&amp;utm_content=Ousret/pyTeliumManager&amp;utm_campaign=Badge_Grade)
 
-![iCT220-Terminal](http://www.tpe.fr/contents/media/ict220%201%20ls%20%2B%20ipp220.jpg)
+<h1 align="center">Welcome to Ingenico for Human 👋 <a href="https://twitter.com/intent/tweet?text=The%20Real%20First%20Universal%20Charset%20%26%20Language%20Detector&url=https://www.github.com/Ousret/pyTeliumManager&hashtags=python,ingenico,credit,cards,debit,developers"><img src="https://img.shields.io/twitter/url/http/shields.io.svg?style=social"/></a></h1>
 
-_Python library to manipulate Ingenico mobile payment device equipped with Telium Manager. RS232/USB._
-_Please note that every payment device with Telium Manager should, in theory, work with this._
+<p align="center">
+  <sup>One of the few library that help you use this kind of hardware</sup><br>
+  <a href="https://travis-ci.org/Ousret/pyTeliumManager">
+    <img src="https://travis-ci.org/Ousret/pyTeliumManager.svg?branch=master"/>
+  </a>
+  <img src="https://img.shields.io/pypi/pyversions/pyTeliumManager.svg?orange=blue" />
+  <a href="https://pepy.tech/project/pyTeliumManager/">
+    <img alt="Download Count /Month" src="https://pepy.tech/badge/pyTeliumManager/month"/>
+  </a>
+  <a href="https://github.com/ousret/pyTeliumManager/blob/master/LICENSE">
+    <img alt="License: MIT" src="https://img.shields.io/badge/license-MIT-purple.svg" target="_blank" />
+  </a>
+  <a href="https://app.codacy.com/project/Ousret/pyTeliumManager/dashboard">
+    <img alt="Code Quality Badge" src="https://api.codacy.com/project/badge/Grade/ff5c954c3c2348ce8f3a1b7bd76e964c"/>
+  </a>
+  <a href="https://codecov.io/gh/Ousret/pyTeliumManager">
+      <img src="https://codecov.io/gh/Ousret/pyTeliumManager/branch/master/graph/badge.svg" />
+  </a>
+  <a href='https://pyteliummanager.readthedocs.io/en/latest/?badge=latest'>
+    <img src='https://readthedocs.org/projects/pyteliummanager/badge/?version=latest' alt='Documentation Status' />
+  </a>
+  <img alt="Download Count Total" src="https://pepy.tech/badge/pyTeliumManager" />
+  <br>
+  <img src="http://www.tpe.fr/contents/media/ict220%201%20ls%20%2B%20ipp220.jpg" width=200/>
+</p>
+
+> Python library to manipulate Ingenico mobile payment device equipped with Telium Manager. RS232/USB.
+> Please note that every payment device with Telium Manager should, in theory, work with this.
 
 ##### PyPi
 
@@ -82,7 +108,7 @@ else:
 4. Press 1 - Param
 5. Select  - Checkout
 6. Select "Enable"
-7. Choose your prefered interface (USB, COM1, COM2)
+7. Choose your preferred interface (USB, COM1, COM2)
 
 **Tested devices:**
 
@@ -95,7 +121,7 @@ Feel free to repport issue if your device isn't compatible with this package.
 
 **Won't work**
 
-- All direct PinPad liaison, also known as iPP3XX. (WiP see issue #2)
+- All direct PinPad liaison, also known as iPP3XX. (see issue #2)
 
 #### Q-A
 

--- a/setup.py
+++ b/setup.py
@@ -2,16 +2,16 @@ from setuptools import setup
 
 setup(
     name='pyTeliumManager',
-    version='2.3.0',
+    version='2.4.0',
     author='Ahmed TAHRI, @Ousret',
-    author_email='ahmed@tahri.space',
+    author_email='ahmed.tahri@cloudnursery.dev',
     description=('A cross-platform point of sales payment manager tool with Telium Manager '
                  'Support every device with Telium Manager like Ingenico terminals.'),
     license='MIT',
     packages=['telium'],
     test_suite='test',
     url='https://github.com/Ousret/pyTeliumManager',
-    download_url='https://github.com/Ousret/pyTeliumManager/archive/2.3.0.tar.gz',
+    download_url='https://github.com/Ousret/pyTeliumManager/archive/2.4.0.tar.gz',
     install_requires=['pyserial>=3.3', 'pycountry>=17.0', 'payment_card_identifier>=0.1.2', 'six'],
     tests_require=['Faker'],
     keywords=['ingenico', 'telium manager', 'telium', 'payment', 'credit card', 'debit card', 'visa', 'mastercard',

--- a/setup.py
+++ b/setup.py
@@ -1,19 +1,4 @@
 from setuptools import setup
-from distutils.extension import Extension
-
-CYTHONIZE_EQUIPPED = False
-
-try:
-    from Cython.Build import cythonize
-    CYTHONIZE_EQUIPPED = True
-except ImportError as e:
-    print('INFO :: Couldn\'t load Cython.')
-
-extensions = [
-    Extension("telium.constant", ["telium/constant.py"]),
-    Extension("telium.payment", ["telium/payment.py"]),
-    Extension("telium.manager", ["telium/manager.py"])
-]
 
 setup(
     name='pyTeliumManager',
@@ -48,6 +33,5 @@ setup(
         'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
-    ],
-    ext_modules=cythonize(extensions) if CYTHONIZE_EQUIPPED else None
+    ]
 )

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ setup(
     test_suite='test',
     url='https://github.com/Ousret/pyTeliumManager',
     download_url='https://github.com/Ousret/pyTeliumManager/archive/2.3.0.tar.gz',
-    install_requires=['pyserial>=3.3', 'pycountry>=17.0', 'payment_card_identifier>=0.1.2', 'hexdump', 'six'],
+    install_requires=['pyserial>=3.3', 'pycountry>=17.0', 'payment_card_identifier>=0.1.2', 'six'],
     tests_require=['Faker'],
     keywords=['ingenico', 'telium manager', 'telium', 'payment', 'credit card', 'debit card', 'visa', 'mastercard',
               'merchant', 'pos'],

--- a/telium/constant.py
+++ b/telium/constant.py
@@ -38,7 +38,7 @@ TERMINAL_NUMERIC_CURRENCY_EUR = '978'
 TERMINAL_NUMERIC_CURRENCY_USD = '840'
 
 TERMINAL_ANSWER_COMPLETE_SIZE = 83  # STX + 2 char + 1 char + 8 char + 1 char + 55 char + 3 char + 10 char + ETX + LRC
-TERMINAL_ANSWER_LIMITED_SIZE = 28   # STX + 2 char + 1 char + 8 char + 1 char + 3 char + 10 char + ETX + LRC
+TERMINAL_ANSWER_LIMITED_SIZE = 28  # STX + 2 char + 1 char + 8 char + 1 char + 3 char + 10 char + ETX + LRC
 
 TERMINAL_ASK_REQUIRED_SIZE = 34
 TERMINAL_MAXIMAL_AMOUNT_REQUESTABLE = 99999.99
@@ -52,3 +52,12 @@ TERMINAL_TRANSACTION_TYPES = {
 }
 
 TERMINAL_PROBABLES_PATH = ['/dev/ttyACM0', '/dev/tty.usbmodem1411']
+
+# Borrowed from curses.ascii, should permit to use it on Windows
+CONTROL_NAMES = [
+    "NUL", "SOH", "STX", "ETX", "EOT", "ENQ", "ACK", "BEL",
+    "BS", "HT", "LF", "VT", "FF", "CR", "SO", "SI",
+    "DLE", "DC1", "DC2", "DC3", "DC4", "NAK", "SYN", "ETB",
+    "CAN", "EM", "SUB", "ESC", "FS", "GS", "RS", "US",
+    "SP"
+]

--- a/telium/hexdump.py
+++ b/telium/hexdump.py
@@ -1,0 +1,18 @@
+def hexdump(src, length=16, sep='.'):
+    """
+    function that help pretty print bytes content
+    thank to https://gist.github.com/7h3rAm/5603718
+    adapted to lib needs.
+    """
+    FILTER = ''.join([(len(repr(chr(x))) == 3) and chr(x) or sep for x in range(256)])
+    lines = []
+    for c in range(0, len(src), length):
+        chars = src[c:c + length]
+        hexstr = ' '.join(["%02x" % ord(x) for x in chars]) if type(chars) is str else ' '.join(
+            ['{:02x}'.format(x) for x in chars])
+        if len(hexstr) > 24:
+            hexstr = "%s %s" % (hexstr[:24], hexstr[24:])
+        printable = ''.join(["%s" % ((ord(x) <= 127 and FILTER[ord(x)]) or sep) for x in chars]) if type(
+            chars) is str else ''.join(['{}'.format((x <= 127 and FILTER[x]) or sep) for x in chars])
+        lines.append("%08x:  %-*s  |%s|" % (c, length * 3, hexstr, printable))
+    print('\n'.join(lines))

--- a/telium/hexdump.py
+++ b/telium/hexdump.py
@@ -6,13 +6,21 @@ def hexdump(src, length=16, sep='.'):
     """
     FILTER = ''.join([(len(repr(chr(x))) == 3) and chr(x) or sep for x in range(256)])
     lines = []
+
     for c in range(0, len(src), length):
         chars = src[c:c + length]
-        hexstr = ' '.join(["%02x" % ord(x) for x in chars]) if type(chars) is str else ' '.join(
+
+        hexstr = ' '.join(["%02x" % ord(x) for x in chars]) if isinstance(chars, str) else ' '.join(
             ['{:02x}'.format(x) for x in chars])
+
         if len(hexstr) > 24:
             hexstr = "%s %s" % (hexstr[:24], hexstr[24:])
-        printable = ''.join(["%s" % ((ord(x) <= 127 and FILTER[ord(x)]) or sep) for x in chars]) if type(
-            chars) is str else ''.join(['{}'.format((x <= 127 and FILTER[x]) or sep) for x in chars])
+
+        printable = ''.join(
+            [
+                "%s" % ((ord(x) <= 127 and FILTER[ord(x)]) or sep) for x in chars
+            ]
+        ) if isinstance(chars, str) else ''.join(['{}'.format((x <= 127 and FILTER[x]) or sep) for x in chars])
+
         lines.append("%08x:  %-*s  |%s|" % (c, length * 3, hexstr, printable))
     print('\n'.join(lines))

--- a/telium/manager.py
+++ b/telium/manager.py
@@ -1,4 +1,3 @@
-import curses.ascii
 from glob import glob
 
 import six
@@ -148,11 +147,11 @@ class Telium:
         :return: True if signal was written to device
         :rtype: bool
         """
-        if signal not in curses.ascii.controlnames:
+        if signal not in CONTROL_NAMES:
             raise SignalDoesNotExistException("The ASCII '%s' code doesn't exist." % signal)
         if self._debugging:
             print('DEBUG :: try send_signal = ', signal)
-        return self._send(chr(curses.ascii.controlnames.index(signal))) == 1
+        return self._send(chr(CONTROL_NAMES.index(signal))) == 1
 
     def _wait_signal(self, signal):
         """
@@ -162,10 +161,10 @@ class Telium:
         :rtype: bool
         """
         one_byte_read = self._device.read(1)
-        expected_char = curses.ascii.controlnames.index(signal)
+        expected_char = CONTROL_NAMES.index(signal)
 
         if self._debugging and len(one_byte_read) == 1:
-            print('DEBUG :: wait_signal_received = ', curses.ascii.controlnames[one_byte_read[0] if six.PY3 else ord(one_byte_read[0])])
+            print('DEBUG :: wait_signal_received = ', CONTROL_NAMES[one_byte_read[0] if six.PY3 else ord(one_byte_read[0])])
 
         return one_byte_read == (expected_char.to_bytes(1, byteorder='big') if six.PY3 else chr(expected_char))
 
@@ -200,11 +199,11 @@ class Telium:
             raise TerminalUnexpectedAnswerException('Raw read expect size = {0} '
                                                     'but actual size = {1}.'.format(expected_size, data_len))
 
-        if raw_data[0] != (curses.ascii.controlnames.index('STX') if six.PY3 else chr(curses.ascii.controlnames.index('STX'))):
+        if raw_data[0] != (CONTROL_NAMES.index('STX') if six.PY3 else chr(CONTROL_NAMES.index('STX'))):
             raise TerminalUnexpectedAnswerException(
                 'The first byte of the answer from terminal should be STX.. Have %02x and except %02x (STX)' % (
-                    raw_data[0], curses.ascii.controlnames.index('STX')))
-        if raw_data[-2] != (curses.ascii.controlnames.index('ETX') if six.PY3 else chr(curses.ascii.controlnames.index('ETX'))):
+                    raw_data[0], CONTROL_NAMES.index('STX')))
+        if raw_data[-2] != (CONTROL_NAMES.index('ETX') if six.PY3 else chr(CONTROL_NAMES.index('ETX'))):
             raise TerminalUnexpectedAnswerException(
                 'The byte before final of the answer from terminal should be ETX')
 

--- a/telium/manager.py
+++ b/telium/manager.py
@@ -209,6 +209,27 @@ class Telium:
 
         return TeliumResponse.decode(raw_data)
 
+    def is_ok(self, raspberry_pi=False):
+        """
+        Should in theory return True if your device is ready to receive order. False otherwise.
+        I can only recommend you to not call this method every time.
+        :param bool raspberry_pi: Set it to True if you'r running Raspberry PI
+        :return: True if device appear to be OK, false otherwise.
+        :rtype: bool
+        """
+        if raspberry_pi:
+            self._device.timeout = 0.3
+            self._device.read(size=1)
+            self._device.timeout = self._device_timeout
+
+        # Send ENQ and wait for ACK
+        self._send_signal('ENQ')
+
+        if not self._wait_signal('ACK'):
+            return False
+
+        return self._send_signal('EOT')
+
     def ask(self, telium_ask, raspberry_pi=False):
         """
         Initialize payment to terminal

--- a/telium/manager.py
+++ b/telium/manager.py
@@ -2,7 +2,7 @@ import curses.ascii
 from glob import glob
 
 import six
-from hexdump import hexdump
+from telium.hexdump import hexdump
 from serial import Serial, EIGHTBITS, PARITY_NONE, STOPBITS_ONE, PARITY_EVEN, SEVENBITS
 
 from telium.constant import *

--- a/telium/payment.py
+++ b/telium/payment.py
@@ -1,4 +1,3 @@
-import curses.ascii
 import hashlib
 import json
 from abc import ABCMeta, abstractmethod
@@ -146,8 +145,8 @@ class TeliumData(six.with_metaclass(ABCMeta, object)):
         :param str packet: RAW string packet
         :return: Framed data with ETX..STX.LRC
         """
-        packet += chr(curses.ascii.controlnames.index('ETX'))
-        return chr(curses.ascii.controlnames.index('STX')) + packet + chr(TeliumData.lrc(packet))
+        packet += chr(CONTROL_NAMES.index('ETX'))
+        return chr(CONTROL_NAMES.index('STX')) + packet + chr(TeliumData.lrc(packet))
 
     @abstractmethod
     def encode(self):

--- a/telium/payment.py
+++ b/telium/payment.py
@@ -94,7 +94,10 @@ class TeliumData(six.with_metaclass(ABCMeta, object)):
 
     @currency_numeric.setter
     def currency_numeric(self, currency):
-        self._currency_numeric = str(currencies.get(alpha_3=currency.upper()).numeric).zfill(3)
+        currency = currencies.get(alpha_3=currency.upper())
+        if currency is None:
+            raise KeyError('"{cur}" is not available in pyCountry currencies list.'.format(cur=currency))
+        self._currency_numeric = str(currency.numeric).zfill(3)
 
     @property
     def private(self):


### PR DESCRIPTION
pyTeliumManager 2.4.0
-----------------------

*Changes :*
  - **Bugfix :** Remove Cython from *setup.py* as it could lead to fatal error.
  - **Bugfix :** Remove *hexdump* as a dependency, it could make py2app, py2exe, .. to fail importing it. Replaced.
  - **Bugfix :** Fix support for Windows as ascii.curses is not easily available on it.
  - **Improvement :** Add is_ok method to check if your device respond to ENQ (at least).

Thank you for using this lib. Hope it has served you well. Any PR would be appreciated. There is so much that can be done.